### PR TITLE
Fix u64 and add some resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Next
+ - Added support for a UINT64 attribute type.
+
 
 ## 0.2.0
  - Add HTTP server running on port 3000. You can toggle stuff on it!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next
- - Added support for a UINT64 attribute type.
+ - Added support for a UINT64 attribute type. (Closes #34)
  - Broadcast discovery for all devices, even if one in the middle fails.
  - Omit attributes from devices with unknown types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Next
  - Added support for a UINT64 attribute type.
-
+ - Broadcast discovery for all devices, even if one in the middle fails.
+ - Omit attributes from devices with unknown types.
 
 ## 0.2.0
  - Add HTTP server running on port 3000. You can toggle stuff on it!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,42 +277,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.8"
+name = "futures"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.8"
+name = "futures-executor"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
-
-[[package]]
-name = "futures-util"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
- "pin-project 1.0.2",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+
+[[package]]
+name = "futures-task"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+
+[[package]]
+name = "futures-util"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite 0.2.6",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -740,9 +793,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -785,6 +838,12 @@ name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -1291,7 +1350,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
  "tracing-core",
 ]
 
@@ -1549,6 +1608,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "clap",
+ "futures",
  "hyper",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,25 +10,26 @@ license = "CC-BY-4.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.42"
-rumqttc = "0.2.0"
-clap = "3.0.0-beta.1"
-slog = {version = "2.5.2", features=["max_level_trace"]}
-slog-term = "2.6.0"
-log = "*"
-url = "2.1.1"
-simple-error = "0.2.1"
-regex = "1"
-lazy_static = "1.4.0"
-tokio = {version = "0.2.22", features=["blocking", "rt-core", "process"]}
-slog-stdlog = "4.0.0"
-slog-scope = "4.3.0"
-subprocess = "0.2.4"
-serde_json = "1.0"
 async-channel = "1.4"
+async-trait = "0.1.42"
+clap = "3.0.0-beta.1"
+futures = "0.3.13"
 hyper = {version = "0.13.9", features=["runtime", "tcp"], default-features=false}
+lazy_static = "1.4.0"
+log = "*"
+regex = "1"
+rumqttc = "0.2.0"
 rust-embed = {version="5.7.0", features=["compression"]}
 serde = {version="1.0.118", features=["derive"]}
+serde_json = "1.0"
+simple-error = "0.2.1"
+slog = {version = "2.5.2", features=["max_level_trace"]}
+slog-scope = "4.3.0"
+slog-stdlog = "4.0.0"
+slog-term = "2.6.0"
+subprocess = "0.2.4"
+tokio = {version = "0.2.22", features=["blocking", "rt-core", "process"]}
+url = "2.1.1"
 
 [profile.release]
 opt-level = 'z'  # Optimize for size.

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -6,7 +6,7 @@ use crate::utils::Numberish;
 use regex::Regex;
 use serde::{Serialize, Serializer};
 use simple_error::{bail, simple_error};
-use slog::debug;
+use slog::{debug, error};
 use slog_scope;
 use std::collections::HashMap;
 use std::future::Future;
@@ -342,7 +342,14 @@ impl DeviceController for AprontestController {
                         )?,
                     })
                 })
-                .collect::<Result<Vec<DeviceAttribute>, Box<dyn Error>>>()?,
+                .filter_map(|v| match v {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        error!(slog_scope::logger(), "failed_to_parse_attribute"; "error" => ?e);
+                        None
+                    }
+                })
+                .collect::<Vec<DeviceAttribute>>(),
         })
     }
 

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -31,6 +31,7 @@ pub enum AttributeType {
     UInt8,
     UInt16,
     UInt32,
+    UInt64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -41,6 +42,7 @@ pub enum AttributeValue {
     UInt8(u8),
     UInt16(u16),
     UInt32(u32),
+    UInt64(u64),
 }
 
 impl AttributeType {
@@ -50,6 +52,7 @@ impl AttributeType {
             AttributeType::UInt8 => AttributeValue::UInt8(payload_str.parse::<u8>()?),
             AttributeType::UInt16 => AttributeValue::UInt16(payload_str.parse::<u16>()?),
             AttributeType::UInt32 => AttributeValue::UInt32(payload_str.parse::<u32>()?),
+            AttributeType::UInt64 => AttributeValue::UInt64(payload_str.parse::<u64>()?),
             AttributeType::String => AttributeValue::String(payload_str.to_string()),
             AttributeType::Bool => {
                 AttributeValue::Bool(match payload_str.to_ascii_lowercase().as_str() {
@@ -82,6 +85,10 @@ impl AttributeType {
                     .ok_or_else(|| simple_error!("{} is not a u64", n))?
                     .try_into()?,
             ),
+            (serde_json::Value::Number(n), AttributeType::UInt64) => AttributeValue::UInt64(
+                n.as_u64()
+                    .ok_or_else(|| simple_error!("{} is not a u64", n))?,
+            ),
             (serde_json::Value::Bool(v), AttributeType::Bool) => AttributeValue::Bool(*v),
             (v, _) => {
                 bail!("unknown value for type {:?}: {}", self, v);
@@ -99,6 +106,7 @@ impl AttributeValue {
             AttributeValue::UInt8(_) => Some(AttributeType::UInt8),
             AttributeValue::UInt16(_) => Some(AttributeType::UInt16),
             AttributeValue::UInt32(_) => Some(AttributeType::UInt32),
+            AttributeValue::UInt64(_) => Some(AttributeType::UInt64),
         }
     }
 
@@ -117,6 +125,7 @@ impl AttributeValue {
             AttributeValue::UInt8(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
             AttributeValue::UInt16(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
             AttributeValue::UInt32(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
+            AttributeValue::UInt64(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
             AttributeValue::String(s) => serde_json::Value::String(s.clone()),
         }
     }
@@ -234,6 +243,7 @@ fn parse_attr_value(t: AttributeType, v: &str) -> Result<AttributeValue, Box<dyn
             AttributeType::UInt8 => AttributeValue::UInt8(v.parse()?),
             AttributeType::UInt16 => AttributeValue::UInt16(v.parse()?),
             AttributeType::UInt32 => AttributeValue::UInt32(v.parse()?),
+            AttributeType::UInt64 => AttributeValue::UInt64(v.parse()?),
             AttributeType::Bool => AttributeValue::Bool(match v {
                 "TRUE" => true,
                 "FALSE" => false,
@@ -311,6 +321,7 @@ impl DeviceController for AprontestController {
                         "UINT8" => AttributeType::UInt8,
                         "UINT16" => AttributeType::UInt16,
                         "UINT32" => AttributeType::UInt32,
+                        "UINT64" => AttributeType::UInt64,
                         "BOOL" => AttributeType::Bool,
                         "STRING" => AttributeType::String,
                         _ => bail!("Bad attribute type: {}", m.name("type").unwrap().as_str()),
@@ -346,6 +357,7 @@ impl DeviceController for AprontestController {
             AttributeValue::UInt8(v) => format!("{}", v),
             AttributeValue::UInt16(v) => format!("{}", v),
             AttributeValue::UInt32(v) => format!("{}", v),
+            AttributeValue::UInt64(v) => format!("{}", v),
             AttributeValue::Bool(v) => if *v { "TRUE" } else { "FALSE" }.to_string(),
             AttributeValue::String(v) => v.clone(),
         };
@@ -731,6 +743,7 @@ New HA Dimmable Light
        61447 |                         PowerSource |  UINT8 |    R |                                1 |
       258048 |                        IdentifyTime | UINT16 |  R/W |                                0 |
      1699842 |               ZB_CurrentFileVersion | UINT32 |    R |                         33554952 |
+     1699843 |                 ArtificialAttribute | UINT64 |    R |                         33554952 |
   4294901760 |                   WK_TransitionTime | UINT16 |  R/W |                                  |
     "###;
 
@@ -739,13 +752,21 @@ New HA Dimmable Light
         let controller = controller_with_output(OTHER_TYPES_DESCRIBE);
 
         let result = controller.describe(2).await.unwrap();
-        assert_eq!(14, result.attributes.len());
+        assert_eq!(15, result.attributes.len());
         assert_eq!(
             AttributeType::UInt32,
-            result.attributes[result.attributes.len() - 2].attribute_type
+            result.attributes[result.attributes.len() - 3].attribute_type
         );
         assert_eq!(
             AttributeValue::UInt32(33554952),
+            result.attributes[result.attributes.len() - 3].current_value
+        );
+        assert_eq!(
+            AttributeType::UInt64,
+            result.attributes[result.attributes.len() - 2].attribute_type
+        );
+        assert_eq!(
+            AttributeValue::UInt64(33554952),
             result.attributes[result.attributes.len() - 2].current_value
         );
     }
@@ -760,9 +781,10 @@ New HA Dimmable Light
             AttributeValue::String("".into()),
             AttributeValue::Bool(true),
             AttributeValue::Bool(false),
-            AttributeValue::UInt8(u8::max_value()),
-            AttributeValue::UInt16(u16::max_value()),
-            AttributeValue::UInt32(u32::max_value()),
+            AttributeValue::UInt8(u8::MAX),
+            AttributeValue::UInt16(u16::MAX),
+            AttributeValue::UInt32(u32::MAX),
+            AttributeValue::UInt64(u64::MAX),
         ];
 
         for test in tests.iter() {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -33,11 +33,12 @@ fn switch_to_discovery_payload(
     let on_off = device.attribute("On_Off").unwrap();
 
     let (payload_on, payload_off) = match on_off.attribute_type {
-        AttributeType::UInt8 => ("0", "255"),
-        AttributeType::UInt16 => ("0", "65535"),
-        AttributeType::UInt32 => ("0", "4294967295"),
-        AttributeType::Bool => ("TRUE", "FALSE"),
-        AttributeType::String => ("ON", "OFF"),
+        AttributeType::UInt8 => ("0", format!("{}", u8::MAX)),
+        AttributeType::UInt16 => ("0", format!("{}", u16::MAX)),
+        AttributeType::UInt32 => ("0", format!("{}", u32::MAX)),
+        AttributeType::UInt64 => ("0", format!("{}", u64::MAX)),
+        AttributeType::Bool => ("TRUE", "FALSE".into()),
+        AttributeType::String => ("ON", "OFF".into()),
     };
 
     let unique_id = format!(
@@ -75,10 +76,11 @@ fn dimmer_to_discovery_payload(
     device: &LongDevice,
 ) -> Result<AutodiscoveryMessage, Box<dyn Error>> {
     let level = device.attribute("Level").unwrap();
-    let scale: u32 = match level.attribute_type {
-        AttributeType::UInt8 => u8::max_value() as u32,
-        AttributeType::UInt16 => u16::max_value() as u32,
-        AttributeType::UInt32 => u32::max_value(),
+    let scale: u64 = match level.attribute_type {
+        AttributeType::UInt8 => u8::MAX as u64,
+        AttributeType::UInt16 => u16::MAX as u64,
+        AttributeType::UInt32 => u32::MAX as u64,
+        AttributeType::UInt64 => u64::MAX,
         AttributeType::Bool => 1,
         AttributeType::String => {
             bail!("A string level type! Please report with `aprontest -l` output!")

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -145,6 +145,8 @@ const AttributeControlLevel = ({attribute, changeValue}) => {
     max = 65535;
   } else if (attribute.attribute_type === 'UInt32') {
     max = 4294967295;
+  } else if (attribute.attribute_type === 'UInt64') {
+    max = 18446744073709550000;
   } else {
     return <div>Unknown Level Type: {attribute.attribute_type}</div>
   }


### PR DESCRIPTION
 - Add uint64 as a valid type.
 - Actually run discovery futures in parallel, so even if one fails, the others can run.
 - Allow unknown attributes to just fall through the cracks.

Closes #34 